### PR TITLE
Remove deprecated disp option from L-BFGS-B calls in examples

### DIFF
--- a/examples/example1_SU2/example.py
+++ b/examples/example1_SU2/example.py
@@ -70,7 +70,7 @@ lb = driver.getLowerBound()
 ub = driver.getUpperBound()
 bounds = np.array((lb,ub),float).transpose()
 max_iters = 200
-options={'disp': True, 'maxcor': 10, 'ftol': 1e-7, 'gtol': 1e-12, 'maxiter': update_iters}
+options={'maxcor': 10, 'ftol': 1e-7, 'gtol': 1e-12, 'maxiter': update_iters}
 
 while not beta.isAtTop():
   optimum = scipy.optimize.minimize(driver.fun, x, method="L-BFGS-B",\

--- a/examples/example2_SU2/example.py
+++ b/examples/example2_SU2/example.py
@@ -65,7 +65,7 @@ ub = driver.getUpperBound()
 transform = BoundConstraints(driver.fun,driver.grad,lb,ub)
 
 max_iters = 200
-options={'disp': True, 'maxcor': 10, 'ftol': 1e-7, 'gtol': 1e-12, 'maxiter': update_iters, 'maxls': 20}
+options={'maxcor': 10, 'ftol': 1e-7, 'gtol': 1e-12, 'maxiter': update_iters, 'maxls': 20}
 
 while not beta.isAtTop():
   x0 = transform.inverse(x)

--- a/examples/example3_SU2/example.py
+++ b/examples/example3_SU2/example.py
@@ -164,7 +164,7 @@ update_iters = 18
 max_iters = 1000
 fin_tol = 1e-7
 
-options={'disp': True, 'maxcor': 10, 'ftol': fin_tol*10, 'gtol': 1e-12, 'maxls': 5, 'maxiter': update_iters}
+options={'maxcor': 10, 'ftol': fin_tol*10, 'gtol': 1e-12, 'maxls': 5, 'maxiter': update_iters}
 
 # respect constraints with grey settings
 while not driver.feasibleDesign() and max_iters > 0:

--- a/examples/example4_SU2/example.py
+++ b/examples/example4_SU2/example.py
@@ -158,7 +158,7 @@ import scipy.optimize
 driver.preprocess()
 x = driver.getInitial()
 
-options = {'disp': True, 'ftol': 1e-7, 'maxiter': 100}
+options = {'ftol': 1e-7, 'maxiter': 100}
 
 optimum = scipy.optimize.minimize(driver.fun, x, method="SLSQP", jac=driver.grad,\
           constraints=driver.getConstraints(), bounds=driver.getBounds(), options=options)


### PR DESCRIPTION
The 'disp' option in scipy.optimize.minimize with L-BFGS-B method 
is deprecated since SciPy 1.15 and will be removed in SciPy 1.18.
Removed from all 4 SU2 examples to eliminate deprecation warnings.

Noticed this while running the examples locally with SU2 v8.4.0 
on Ubuntu 22.04 (WSL2).